### PR TITLE
Output \n as a string in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ruby -r numo/narray -e "puts Numo::DFloat.new(1000).rand_norm.to_a" \
 ```sh
 echo "from numpy import random;" \
      "n = random.randn(10000);"  \
-     "print('\n'.join(str(i) for i in n))" \
+     "print('\\\n'.join(str(i) for i in n))" \
 | python \
 | uplot hist --nbins 20
 ```


### PR DESCRIPTION
Current output is:

```sh
$ echo "from numpy import random;" \
>      "n = random.randn(10000);"  \
>      "print('\n'.join(str(i) for i in n))"
from numpy import random; n = random.randn(10000); print('
'.join(str(i) for i in n))
```

After this change, I think it is originally expected string:

```sh
$ echo "from numpy import random;" \
>      "n = random.randn(10000);"  \
>      "print('\\\n'.join(str(i) for i in n))"
from numpy import random; n = random.randn(10000); print('\n'.join(str(i) for i in n))
```
